### PR TITLE
removes an unvisible character

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -38,7 +38,7 @@ delayTailKill() {
 }
 delayTailKill &>/dev/null &
 
-( tail -f -n +1 /tmp/cloudsql.log & ) | grep -q "Ready for new connections" || true
+( tail -f -n +1 /tmp/cloudsql.log & ) | grep -q "Ready for new connections" || true
 
 # Remove SA json from the tmp folder
 # Nobody should have access either way, but just to check


### PR DESCRIPTION
Removes a redundant Unicode character (see the screenshot below), which causes the following error for staging the CI job:

```
Starting the cloudsql proxy
Waiting for ready message from cloudsql proxy...
/startup.sh: line 41: $'\302\240true': command not found
```

<img width="914" alt="Screenshot 2024-01-11 at 12 18 29" src="https://github.com/travelaudience/docker-cloudsql-goose/assets/17885343/57c86228-8469-4918-900a-ad05d6a45ef0">
