### PR TITLE
DEVOPS-3012: Update ta-docker orb to 3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs: 
-  ta-docker: travelaudience/docker@2.1
+  ta-docker: travelaudience/docker@3.2
 
 version: 2.1
 workflows:

--- a/startup.sh
+++ b/startup.sh
@@ -15,7 +15,7 @@ if [[ -z "${GCLOUD_SQL_INSTANCE}" ]]; then
     exit 1
 fi
 
-export GOOSE_DBSTRING="user=${POSTGRES_USER} password=${POSTGRES_PASSWORD} dbname=${POSTGRES_DATABASE} sslmode=disable host=localhost port=${POSTGRES_PORT}"
+export GOOSE_DBSTRING="user='${POSTGRES_USER}' password='${POSTGRES_PASSWORD}' dbname='${POSTGRES_DATABASE}' sslmode=disable host=localhost port=${POSTGRES_PORT}"
 
 echo "Starting the cloudsql proxy"
 touch /tmp/cloudsql.log


### PR DESCRIPTION
DEVOPS-3012: Since CircleCI is deprecating deploy steps in favor of run steps, we need to update our workflows (and their dependencies) accordingly. More information can be found here: https://circleci.com/docs/migrate-from-deploy-to-run/